### PR TITLE
Detect all markdown link syntaxes + minor fixes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -29,15 +29,15 @@ enum itemTypes {
 }
 
 interface LinkMention {
-  path: string;
-  headings: Array<string>;
+	path: string;
+	headings: Array<string>;
 }
-  
+
 interface AutoMOCSettings {
 	//general
 	showRibbonButton: boolean;
 	linkToHeading: boolean;
-  linkToHeadingBefore: boolean;
+	linkToHeadingBefore: boolean;
 	linkWithAlias: boolean;
 	importAsList: string;
 	orderedListSeparator: string;
@@ -53,7 +53,7 @@ const DEFAULT_SETTINGS: AutoMOCSettings = {
 	//general
 	showRibbonButton: true,
 	linkToHeading: false,
-  linkToHeadingBefore: false,
+	linkToHeadingBefore: false,
 	linkWithAlias: true,
 	importAsList: importListTypes.Disabled,
 	orderedListSeparator: orderedListDelimeters.Period,
@@ -218,85 +218,85 @@ export default class AutoMOC extends Plugin {
 		return presentLinks.sort();
 	}
 
-  async getHeadings(path: string, activeFileView: MarkdownView, item?: string, linkLocations?: Array<number>) {
-    let closestHeading = "";
-    let allHeadings: Array<string> = [];
+	async getHeadings(path: string, activeFileView: MarkdownView, item?: string, linkLocations?: Array<number>) {
+		let closestHeading = "";
+		let allHeadings: Array<string> = [];
 
-    if (this.settings.linkToHeading) {
-      const headingsLocations =
-        await this.getHeadingsLocationsInFile(path);
-      let linkTagLocations: Array<number> = [];
-      if (linkLocations) {
-        linkTagLocations = linkLocations;
-      }
-      else {
-        linkTagLocations =
-        await this.getItemLocationsInFile(
-          activeFileView,
-          path,
-          item
-        );
-      }
-      for (let i = 0; i < linkTagLocations.length; i++) {
-        closestHeading = this.determineClosestHeading(
-          headingsLocations,
-          linkTagLocations[i]
-        );
-        if (closestHeading) allHeadings.push(closestHeading);
-      }
-    }
-    return allHeadings;
-  }
-  
+		if (this.settings.linkToHeading) {
+			const headingsLocations =
+				await this.getHeadingsLocationsInFile(path);
+			let linkTagLocations: Array<number> = [];
+			if (linkLocations) {
+				linkTagLocations = linkLocations;
+			}
+			else {
+				linkTagLocations =
+				await this.getItemLocationsInFile(
+					activeFileView,
+					path,
+					item
+				);
+			}
+			for (let i = 0; i < linkTagLocations.length; i++) {
+				closestHeading = this.determineClosestHeading(
+					headingsLocations,
+					linkTagLocations[i]
+				);
+				if (closestHeading) allHeadings.push(closestHeading);
+			}
+		}
+		return allHeadings;
+	}
+
 	async getLinkedMentions(currFilePath: string, activeFileView: MarkdownView, item?: string) {
-    let linkedMentions: Array<LinkMention> = [];
-    
-    let directSuccess = false;
-    if (typeof this.app.metadataCache.getBacklinksForFile === 'function') {
-      // this is better than the manual approach as it will take in account all markdown link syntax
-      // and will do everything in one step
-      // but this is not in the officla API, so let's keep the old approach too
-      
-      const file = this.app.vault.getAbstractFileByPath(currFilePath);
-      const backLinks = this.app.metadataCache.getBacklinksForFile(file);
-      if (backLinks && backLinks.data) {
-        directSuccess = true;
-        for (const linkFile of backLinks.data) {
-          if (linkFile.length >= 2) {
-            const linkPath = linkFile[0];
-            let linkLocations: Array<number> = [];
-            for (const iter of linkFile[1]) {
-              if (iter.position && iter.position.start) {
-                linkLocations.push(iter.position.start.line);
-              }            
-            }
-            const allHeadings: Array<string> = await this.getHeadings(linkPath, activeFileView, item, linkLocations);
-            linkedMentions.push({path: linkPath, headings: allHeadings});
-          }
-        }
-      }
-    }
-    
-    if (!directSuccess) {
-      const allFiles = this.app.metadataCache.resolvedLinks;
-  
-      let ignoredFolders = this.settings.ignoredFolders
-        .trim()
-        .split(",")
-        .map((str) => str.trim().replace(/^\/|\/$/g, ""))
-        .filter((n) => n);
-  
-      for (const key of Object.keys(allFiles)) {
-        if (!ignoredFolders.some((path) => key.includes(path))) {
-          //check if file is in an ignored folder
-          if (currFilePath in allFiles[key]) {
-            const allHeadings: Array<string> = await this.getHeadings(key, activeFileView, item);
-            linkedMentions.push({path: key, headings: allHeadings});
-          }
-        }
-      }
-    }
-    // let's sort the array case insensitive
+		let linkedMentions: Array<LinkMention> = [];
+
+		let directSuccess = false;
+		if (typeof this.app.metadataCache.getBacklinksForFile === 'function') {
+			// this is better than the manual approach as it will take in account all markdown link syntax
+			// and will do everything in one step
+			// but this is not in the officla API, so let's keep the old approach too
+
+			const file = this.app.vault.getAbstractFileByPath(currFilePath);
+			const backLinks = this.app.metadataCache.getBacklinksForFile(file);
+			if (backLinks && backLinks.data) {
+				directSuccess = true;
+				for (const linkFile of backLinks.data) {
+					if (linkFile.length >= 2) {
+						const linkPath = linkFile[0];
+						let linkLocations: Array<number> = [];
+						for (const iter of linkFile[1]) {
+							if (iter.position && iter.position.start) {
+								linkLocations.push(iter.position.start.line);
+							}
+						}
+						const allHeadings: Array<string> = await this.getHeadings(linkPath, activeFileView, item, linkLocations);
+						linkedMentions.push({path: linkPath, headings: allHeadings});
+					}
+				}
+			}
+		}
+
+		if (!directSuccess) {
+			const allFiles = this.app.metadataCache.resolvedLinks;
+
+			let ignoredFolders = this.settings.ignoredFolders
+				.trim()
+				.split(",")
+				.map((str) => str.trim().replace(/^\/|\/$/g, ""))
+				.filter((n) => n);
+
+			for (const key of Object.keys(allFiles)) {
+				if (!ignoredFolders.some((path) => key.includes(path))) {
+					//check if file is in an ignored folder
+					if (currFilePath in allFiles[key]) {
+						const allHeadings: Array<string> = await this.getHeadings(key, activeFileView, item);
+						linkedMentions.push({path: key, headings: allHeadings});
+					}
+				}
+			}
+		}
+		// let's sort the array case insensitive
 		return linkedMentions.sort((a, b) => a.path.localeCompare(b.path, undefined, {sensitivity: 'base'}));
 	}
 
@@ -355,15 +355,15 @@ export default class AutoMOC extends Plugin {
 
 		const uniqueTaggedMentions = taggedMentions.filter(
 			(value, index, array) => {
-        const pos = array.findIndex((element) => element.path == value.path);
-        return pos === index;
-      }
+				const pos = array.findIndex((element) => element.path == value.path);
+				return pos === index;
+			}
 		);
-    
-    for (let mention of uniqueTaggedMentions) {
-      mention.headings = await this.getHeadings(mention.path, activeFileView, tag);
-    }
-    
+
+		for (let mention of uniqueTaggedMentions) {
+			mention.headings = await this.getHeadings(mention.path, activeFileView, tag);
+		}
+
 		return uniqueTaggedMentions;
 	}
 
@@ -412,15 +412,15 @@ export default class AutoMOC extends Plugin {
 
 		const uniqueAliasMentions = aliasMentions.filter(
 			(value, index, array) => {
-        const pos = array.findIndex((element) => element.path == value.path);
-        return pos === index;
-      }
+				const pos = array.findIndex((element) => element.path == value.path);
+				return pos === index;
+			}
 		);
 
-    for (let mention of uniqueAliasMentions) {
-      mention.headings = await this.getHeadings(mention.path, activeFileView, tag);
-    }
-    
+		for (let mention of uniqueAliasMentions) {
+			mention.headings = await this.getHeadings(mention.path, activeFileView, tag);
+		}
+
 		return uniqueAliasMentions;
 	}
 
@@ -451,7 +451,7 @@ export default class AutoMOC extends Plugin {
 
 		//checks for missing links and adds them
 		for (const mention of allLinkedMentions) {
-      const path = mention.path;
+			const path = mention.path;
 			if (!presentLinks.includes(path)) {
 				const file = this.app.vault.getAbstractFileByPath(path);
 
@@ -579,27 +579,27 @@ export default class AutoMOC extends Plugin {
 		let distances: Array<number> = [];
 
 		headingsLocations.forEach((item, index) => {
-      let distance = Infinity;
+			let distance = Infinity;
 			if (item != "-1") {
-        if (this.settings.linkToHeadingBefore) {
-          if (index <= itemLocation) {
-            distance = itemLocation - index;
-          }
-        }
-        else {
-          distance = Math.abs(index - itemLocation);
-        }
-      }
+				if (this.settings.linkToHeadingBefore) {
+					if (index <= itemLocation) {
+						distance = itemLocation - index;
+					}
+				}
+				else {
+					distance = Math.abs(index - itemLocation);
+				}
+			}
 			distances.push(distance);
 		});
 
 		let minIndex = -1;
 		let minValue = Infinity;
 		for (let i = 0; i < distances.length; i += 1) {
-      if (distances[i] < minValue) {
-        minIndex = i;
-        minValue = distances[i];
-      }
+			if (distances[i] < minValue) {
+				minIndex = i;
+				minValue = distances[i];
+			}
 		}
 
 		if (minIndex === itemLocation) {
@@ -742,7 +742,7 @@ class AutoMOCSettingTab extends PluginSettingTab {
 					});
 			});
 
-    new Setting(containerEl)
+		new Setting(containerEl)
 			.setName("Only search for previous headings")
 			.setDesc(
 				"This ensure that preview or embeded links will show the right file portion."

--- a/main.ts
+++ b/main.ts
@@ -37,6 +37,7 @@ interface AutoMOCSettings {
 	//general
 	showRibbonButton: boolean;
 	linkToHeading: boolean;
+  linkToHeadingBefore: boolean;
 	linkWithAlias: boolean;
 	importAsList: string;
 	orderedListSeparator: string;
@@ -52,6 +53,7 @@ const DEFAULT_SETTINGS: AutoMOCSettings = {
 	//general
 	showRibbonButton: true,
 	linkToHeading: false,
+  linkToHeadingBefore: false,
 	linkWithAlias: true,
 	importAsList: importListTypes.Disabled,
 	orderedListSeparator: orderedListDelimeters.Period,
@@ -577,19 +579,27 @@ export default class AutoMOC extends Plugin {
 		let distances: Array<number> = [];
 
 		headingsLocations.forEach((item, index) => {
-			if (item != "-1") distances.push(Math.abs(index - itemLocation));
-			else distances.push(-1);
+      let distance = Infinity;
+			if (item != "-1") {
+        if (this.settings.linkToHeadingBefore) {
+          if (index <= itemLocation) {
+            distance = itemLocation - index;
+          }
+        }
+        else {
+          distance = Math.abs(index - itemLocation);
+        }
+      }
+			distances.push(distance);
 		});
 
 		let minIndex = -1;
 		let minValue = Infinity;
 		for (let i = 0; i < distances.length; i += 1) {
-			if (distances[i] != -1) {
-				if (distances[i] < minValue) {
-					minIndex = i;
-					minValue = distances[i];
-				}
-			}
+      if (distances[i] < minValue) {
+        minIndex = i;
+        minValue = distances[i];
+      }
 		}
 
 		if (minIndex === itemLocation) {
@@ -728,6 +738,20 @@ class AutoMOCSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.linkToHeading)
 					.onChange((linkToHeading) => {
 						this.plugin.settings.linkToHeading = linkToHeading;
+						this.plugin.saveSettings();
+					});
+			});
+
+    new Setting(containerEl)
+			.setName("Only search for previous headings")
+			.setDesc(
+				"This ensure that preview or embeded links will show the right file portion."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.linkToHeadingBefore)
+					.onChange((linkToHeadingBefore) => {
+						this.plugin.settings.linkToHeadingBefore = linkToHeadingBefore;
 						this.plugin.saveSettings();
 					});
 			});

--- a/main.ts
+++ b/main.ts
@@ -242,7 +242,7 @@ export default class AutoMOC extends Plugin {
           headingsLocations,
           linkTagLocations[i]
         );
-        allHeadings.push(closestHeading);
+        if (closestHeading) allHeadings.push(closestHeading);
       }
     }
     return allHeadings;

--- a/main.ts
+++ b/main.ts
@@ -28,6 +28,11 @@ enum itemTypes {
 	Alias = "ALIAS",
 }
 
+interface LinkMention {
+  path: string;
+  headings: Array<string>;
+}
+  
 interface AutoMOCSettings {
 	//general
 	showRibbonButton: boolean;
@@ -211,9 +216,33 @@ export default class AutoMOC extends Plugin {
 		return presentLinks.sort();
 	}
 
-	getLinkedMentions(currFilePath: string) {
+  async getHeadings(path: string, activeFileView: MarkdownView, item?: string) {
+    let closestHeading = "";
+    let allHeadings: Array<string> = [];
+
+    if (this.settings.linkToHeading) {
+      const headingsLocations =
+        await this.getHeadingsLocationsInFile(path);
+      const linkTagLocations =
+        await this.getItemLocationsInFile(
+          activeFileView,
+          path,
+          item
+        );
+      for (let i = 0; i < linkTagLocations.length; i++) {
+        closestHeading = this.determineClosestHeading(
+          headingsLocations,
+          linkTagLocations[i]
+        );
+        allHeadings.push(closestHeading);
+      }
+    }
+    return allHeadings;
+  }
+  
+	async getLinkedMentions(currFilePath: string, activeFileView: MarkdownView, item?: string) {
 		const allFiles = this.app.metadataCache.resolvedLinks;
-		let linkedMentions: Array<string> = [];
+		let linkedMentions: Array<LinkMention> = [];
 
 		let ignoredFolders = this.settings.ignoredFolders
 			.trim()
@@ -221,21 +250,22 @@ export default class AutoMOC extends Plugin {
 			.map((str) => str.trim().replace(/^\/|\/$/g, ""))
 			.filter((n) => n);
 
-		Object.keys(allFiles).forEach((key) => {
+    for (const key of Object.keys(allFiles)) {
 			if (!ignoredFolders.some((path) => key.includes(path))) {
 				//check if file is in an ignored folder
 				if (currFilePath in allFiles[key]) {
-					linkedMentions.push(key);
+          const allHeadings: Array<string> = await this.getHeadings(key, activeFileView, item);
+					linkedMentions.push({path: key, headings: allHeadings});
 				}
 			}
-		});
+		}
 
-		return linkedMentions.sort();
+		return linkedMentions.sort((a, b) => a.path.localeCompare(b.path, undefined, {sensitivity: 'base'}));
 	}
 
-	getTaggedMentions(tag: string) {
+	async getTaggedMentions(currFilePath: string, activeFileView: MarkdownView, tag: string) {
 		const allFiles = this.app.metadataCache.resolvedLinks;
-		let taggedMentions: Array<string> = [];
+		let taggedMentions: Array<LinkMention> = [];
 		const toCompare = tag.replace("#", "");
 
 		let ignoredFolders = this.settings.ignoredFolders
@@ -244,7 +274,7 @@ export default class AutoMOC extends Plugin {
 			.map((str) => str.trim().replace(/^\/|\/$/g, ""))
 			.filter((n) => n);
 
-		Object.keys(allFiles).forEach((key) => {
+		for (const key of Object.keys(allFiles)) {
 			//check if file is in an ignored folder
 			if (!ignoredFolders.some((path) => key.includes(path))) {
 				const file = this.app.vault.getAbstractFileByPath(key);
@@ -256,7 +286,7 @@ export default class AutoMOC extends Plugin {
 					if (body_tags) {
 						for (const tag of body_tags) {
 							if (tag["tag"].replace("#", "") === toCompare) {
-								taggedMentions.push(file.path);
+								taggedMentions.push({path: file.path, headings: []});
 							}
 						}
 					}
@@ -268,7 +298,7 @@ export default class AutoMOC extends Plugin {
 
 							for (const f_tag of f_tags) {
 								if (f_tag === toCompare) {
-									taggedMentions.push(file.path);
+									taggedMentions.push({path: file.path, headings: []});
 								}
 							}
 						}
@@ -277,25 +307,29 @@ export default class AutoMOC extends Plugin {
 
 							for (const f_tag of f_tags) {
 								if (f_tag === toCompare) {
-									taggedMentions.push(file.path);
+									taggedMentions.push({path: file.path, headings: []});
 								}
 							}
 						}
 					}
 				}
 			}
-		});
+		}
 
 		const uniqueTaggedMentions = taggedMentions.filter(
 			(value, index, array) => array.indexOf(value) === index
 		);
-
+    
+    for (let mention of uniqueTaggedMentions) {
+      mention.headings = await this.getHeadings(mention.path, activeFileView, tag);
+    }
+    
 		return uniqueTaggedMentions;
 	}
 
-	getAliasMentions(refAlias: string) {
+	async getAliasMentions(currFilePath: string, activeFileView: MarkdownView, refAlias: string) {
 		const allFiles = this.app.metadataCache.resolvedLinks;
-		let aliasMentions: Array<string> = [];
+		let aliasMentions: Array<LinkMention> = [];
 
 		let ignoredFolders = this.settings.ignoredFolders
 			.trim()
@@ -303,7 +337,7 @@ export default class AutoMOC extends Plugin {
 			.map((str) => str.trim().replace(/^\/|\/$/g, ""))
 			.filter((n) => n);
 
-		Object.keys(allFiles).forEach((key) => {
+		for (const key of Object.keys(allFiles)) {
 			//check if file is in an ignored folder
 			if (!ignoredFolders.some((path) => key.includes(path))) {
 				const file = this.app.vault.getAbstractFileByPath(key);
@@ -318,7 +352,7 @@ export default class AutoMOC extends Plugin {
 
 							for (const alias of aliases) {
 								if (alias === refAlias) {
-									aliasMentions.push(file.path);
+									aliasMentions.push({path: file.path, headings: []});
 								}
 							}
 						}
@@ -327,26 +361,30 @@ export default class AutoMOC extends Plugin {
 
 							for (const alias of aliases) {
 								if (alias === refAlias) {
-									aliasMentions.push(file.path);
+									aliasMentions.push({path: file.path, headings: []});
 								}
 							}
 						}
 					}
 				}
 			}
-		});
+		}
 
 		const uniqueAliasMentions = aliasMentions.filter(
 			(value, index, array) => array.indexOf(value) === index
 		);
 
+    for (let mention of uniqueAliasMentions) {
+      mention.headings = await this.getHeadings(mention.path, activeFileView, tag);
+    }
+    
 		return uniqueAliasMentions;
 	}
 
 	async addMissingLinks(
 		activeFileView: MarkdownView,
 		presentLinks: Array<string>,
-		allLinkedMentions: Array<string>,
+		allLinkedMentions: Array<LinkMention>,
 		item?: string
 	) {
 		let addFlag = false;
@@ -369,7 +407,8 @@ export default class AutoMOC extends Plugin {
 		}
 
 		//checks for missing links and adds them
-		for (const path of allLinkedMentions) {
+		for (const mention of allLinkedMentions) {
+      const path = mention.path;
 			if (!presentLinks.includes(path)) {
 				const file = this.app.vault.getAbstractFileByPath(path);
 
@@ -388,26 +427,7 @@ export default class AutoMOC extends Plugin {
 						alias = frontmatter.aliases[0];
 					}
 
-					let closestHeading = "";
-					let allHeadings: Array<string> = [];
-
-					if (this.settings.linkToHeading) {
-						const headingsLocations =
-							await this.getHeadingsLocationsInFile(path);
-						const linkTagLocations =
-							await this.getItemLocationsInFile(
-								activeFileView,
-								path,
-								item
-							);
-						for (let i = 0; i < linkTagLocations.length; i++) {
-							closestHeading = this.determineClosestHeading(
-								headingsLocations,
-								linkTagLocations[i]
-							);
-							allHeadings.push(closestHeading);
-						}
-					}
+					let allHeadings: Array<string> = mention.headings;
 
 					if (allHeadings.length > 0) {
 						//if there is a closest heading, link to heading
@@ -540,7 +560,7 @@ export default class AutoMOC extends Plugin {
 		return headingsLocations[minIndex];
 	}
 
-	runAutoMOC(itemType: string, item?: string) {
+	async runAutoMOC(itemType: string, item?: string) {
 		if (!Object.values<string>(itemTypes).includes(itemType)) {
 			new Notice("Invalid itemType provided");
 			return;
@@ -554,13 +574,13 @@ export default class AutoMOC extends Plugin {
 
 			const presentLinks = this.getPresentLinks(view.file.path); // links already in the document
 
-			let linkTagMentions: Array<string>;
+			let linkTagMentions: Array<LinkMention>;
 			if (itemType == itemTypes.Link) {
-				linkTagMentions = this.getLinkedMentions(view.file.path); // all linked mentions even those not present
+				linkTagMentions = await this.getLinkedMentions(view.file.path, view, item); // all linked mentions even those not present
 			} else if (itemType == itemTypes.Tag) {
-				linkTagMentions = this.getTaggedMentions(item); // tagged mentions are looked up by basename rather than path
+				linkTagMentions = await this.getTaggedMentions(view.file.path, view, item); // tagged mentions are looked up by basename rather than path
 			} else if (itemType == itemTypes.Alias) {
-				linkTagMentions = this.getAliasMentions(item); // alias mentions are looked up by basename rather than path
+				linkTagMentions = await this.getAliasMentions(view.file.path, view, item); // alias mentions are looked up by basename rather than path
 			}
 
 			this.addMissingLinks(view, presentLinks, linkTagMentions, item);


### PR DESCRIPTION
This PR : 
- Fix the detection of all markdown syntaxes of links, not just "wikilinks". Under the hood, this use a function not defined in the official API, thus I've also kept the old code in case the function disappear at some point... btw, this new code is a little bit "direct", as it avoid to search for the link position in file.
- Fix link to "undefined" header if we can't find any header.
- Add a new setting to only search for headers before the link. This allow to easily use embedded links (just add `!` before the link) and simplify the link search in very long notes (no need to guess in which direction to scroll).

Note that the first point as need some code refactoring.
It's my first PR here, hope it's ok. Otherwise, just ask for changes.